### PR TITLE
Upgrade deprecated runtime nodejs12.x

### DIFF
--- a/amplify/backend/analytics/powertoolkit/pinpoint-cloudformation-template.json
+++ b/amplify/backend/analytics/powertoolkit/pinpoint-cloudformation-template.json
@@ -248,7 +248,7 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300,
         "Role": {
           "Fn::GetAtt": [


### PR DESCRIPTION
CloudFormation templates in aws-amplify-flutter-example have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs12.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.